### PR TITLE
Fix coverage script and recover missing coverage

### DIFF
--- a/coverage/branches.csv
+++ b/coverage/branches.csv
@@ -1,4 +1,1 @@
-ActiveUsersService.ts,1
-AttackEpaminondasMinimax.ts,1
 online-game-wrapper.component.ts,3
-PositionalEpaminondasMinimax.ts,1

--- a/coverage/functions.csv
+++ b/coverage/functions.csv
@@ -1,2 +1,2 @@
 ActiveUsersService.ts,3
-ConnectedUserService.ts,2
+ConnectedUserService.ts,1

--- a/coverage/lines.csv
+++ b/coverage/lines.csv
@@ -1,4 +1,4 @@
 ActiveUsersService.ts,3
-ConnectedUserService.ts,3
-online-game-wrapper.component.ts,5
+ConnectedUserService.ts,2
+online-game-wrapper.component.ts,4
 PositionalEpaminondasMinimax.ts,1

--- a/coverage/statements.csv
+++ b/coverage/statements.csv
@@ -1,4 +1,4 @@
 ActiveUsersService.ts,4
-ConnectedUserService.ts,3
-online-game-wrapper.component.ts,5
+ConnectedUserService.ts,2
+online-game-wrapper.component.ts,4
 PositionalEpaminondasMinimax.ts,1

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -18,7 +18,10 @@ def to_missing(x):
     return int(high)-int(low)
 
 def load_coverage_data():
-    files = glob("coverage/src/**/*.ts.html", recursive=True)
+    files = glob("coverage/app/**/*.ts.html", recursive=True)
+    if files == []:
+        print('ERROR: No file found! Check the path to the coverage files.')
+        exit(1)
     data = {
         'statements': {},
         'branches': {},

--- a/src/app/games/diam/DiamMove.ts
+++ b/src/app/games/diam/DiamMove.ts
@@ -22,11 +22,13 @@ export class DiamMoveDrop extends Move {
     public getTarget(): number {
         return this.target;
     }
-    public equals(other: DiamMoveDrop): boolean {
-        if (other instanceof DiamMoveDrop === false) return false;
-        if (this.target !== other.target) return false;
-        if (this.piece !== other.piece) return false;
-        return true;
+    public equals(other: DiamMove): boolean {
+        if (other instanceof DiamMoveDrop) {
+            if (this.target !== other.target) return false;
+            if (this.piece !== other.piece) return false;
+            return true;
+        }
+        return false;
     }
     public toString(): string {
         return `DiamMoveDrop(${this.target}, ${this.piece})`;

--- a/src/app/games/diam/tests/DiamMove.spec.ts
+++ b/src/app/games/diam/tests/DiamMove.spec.ts
@@ -10,12 +10,14 @@ describe('DiamMove', () => {
             expect(() => new DiamMoveDrop(3, DiamPiece.EMPTY)).toThrowError('Cannot drop an empty piece');
         });
         it('should correctly define equality', () => {
-            const move1: DiamMoveDrop = new DiamMoveDrop(3, DiamPiece.ZERO_FIRST);
-            const move2: DiamMoveDrop = new DiamMoveDrop(3, DiamPiece.ZERO_SECOND);
-            const move3: DiamMoveDrop = new DiamMoveDrop(1, DiamPiece.ZERO_FIRST);
-            expect(move1.equals(move1)).toBeTrue();
-            expect(move1.equals(move2)).toBeFalse();
-            expect(move1.equals(move3)).toBeFalse();
+            const move: DiamMoveDrop = new DiamMoveDrop(3, DiamPiece.ZERO_FIRST);
+            const moveDifferentPiece: DiamMoveDrop = new DiamMoveDrop(3, DiamPiece.ZERO_SECOND);
+            const moveDifferentTarget: DiamMoveDrop = new DiamMoveDrop(1, DiamPiece.ZERO_FIRST);
+            const shiftMove: DiamMoveShift = new DiamMoveShift(new Coord(0, 0), 'clockwise');
+            expect(move.equals(move)).toBeTrue();
+            expect(move.equals(moveDifferentPiece)).toBeFalse();
+            expect(move.equals(moveDifferentTarget)).toBeFalse();
+            expect(move.equals(shiftMove)).toBeFalse();
         });
         it('should redefine toString', () => {
             const move: DiamMoveDrop = new DiamMoveDrop(3, DiamPiece.ZERO_FIRST);

--- a/src/app/games/six/SixState.ts
+++ b/src/app/games/six/SixState.ts
@@ -44,9 +44,6 @@ export class SixState extends OpenHexagonalGameState<Player> {
         pieces.set(move.landing, this.getCurrentPlayer());
         return new SixState(pieces, this.turn);
     }
-    public isEmpty(piece: PlayerOrNone): boolean {
-        return piece === PlayerOrNone.NONE;
-    }
     public toRepresentation(): NumberTable {
         const board: number[][] = ArrayUtils.createTable(this.width, this.height, PlayerOrNone.NONE.value);
         for (const piece of this.pieces.listKeys()) {

--- a/src/app/utils/tests/ArrayUtils.spec.ts
+++ b/src/app/utils/tests/ArrayUtils.spec.ts
@@ -22,6 +22,23 @@ describe('ArrayUtils', () => {
             expect(ArrayUtils.compareTable(table, table)).toBeTrue();
         });
     });
+    describe('isPrefix', () => {
+        it('should be false when the prefix is longer than the list', () => {
+            const prefix: number[] = [1, 2, 3];
+            const list: number[] = [1];
+            expect(ArrayUtils.isPrefix(prefix, list)).toBeFalse();
+        });
+        it('should be false when we the prefix is not a prefix', () => {
+            const prefix: number[] = [1, 4];
+            const list: number[] = [1, 2, 3];
+            expect(ArrayUtils.isPrefix(prefix, list)).toBeFalse();
+        });
+        it('should be true when we have a prefix', () => {
+            const prefix: number[] = [1, 2, 3];
+            const list: number[] = [1, 2, 3, 4, 5];
+            expect(ArrayUtils.isPrefix(prefix, list)).toBeTrue();
+        });
+    });
 });
 
 describe('Table2DWithPossibleNegativeIndices', () => {

--- a/src/app/utils/tests/MGPSet.spec.ts
+++ b/src/app/utils/tests/MGPSet.spec.ts
@@ -90,4 +90,22 @@ describe('MGPSet', () => {
             expect(set.equals(new MGPSet([1, 2]))).toBeTrue();
         });
     });
+    describe('map', () => {
+        it('should iterate over the elements of the set', () => {
+            const set: MGPSet<number> = new MGPSet([1, 2]);
+            function add1(x: number): number {
+                return x+1;
+            }
+            expect(set.map(add1).equals(new MGPSet([2, 3]))).toBeTrue();
+        });
+    });
+    describe('flatMap', () => {
+        it('should iterate over the elements of the set, and then flatten it again', () => {
+            const set: MGPSet<number> = new MGPSet([1, 2]);
+            function makeTwo(x: number): MGPSet<number> {
+                return new MGPSet([x, x+1]);
+            }
+            expect(set.flatMap(makeTwo).equals(new MGPSet([1, 2, 3]))).toBeTrue();
+        });
+    });
 });

--- a/src/app/utils/tests/MGPSet.spec.ts
+++ b/src/app/utils/tests/MGPSet.spec.ts
@@ -93,10 +93,10 @@ describe('MGPSet', () => {
     describe('map', () => {
         it('should iterate over the elements of the set', () => {
             const set: MGPSet<number> = new MGPSet([1, 2]);
-            function add1(x: number): number {
+            function increment(x: number): number {
                 return x+1;
             }
-            expect(set.map(add1).equals(new MGPSet([2, 3]))).toBeTrue();
+            expect(set.map(increment).equals(new MGPSet([2, 3]))).toBeTrue();
         });
     });
     describe('flatMap', () => {


### PR DESCRIPTION
`./scripts/coverage.py check` was using the wrong directory to fetch coverage files.
Now it takes them from `coverage/app`, which is where they are. This probably changed in a recent version of Angular.
I also recovered the newly introduced uncovered code.