### PR TITLE
[netlify-deploy] Loosen CI restrictions to deploy feature branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -210,10 +210,6 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         run: |
           echo "${{ secrets.FIREBASE_CONFIG_DEV }}" > src/app/firebaseConfig.ts
-      - name: Setup dependencies (setup Firebase secret, others)
-        if: ${{ github.ref != 'refs/heads/master'  && github.ref != 'refs/heads/develop' }}
-        run: |
-          echo "${{ secrets.FIREBASE_CONFIG_TEST }}" > src/app/firebaseConfig.ts
       - name: Check if push by an org member
         id: is_organization_member
         uses: jamessingleton/is-organization-member@1.0.1
@@ -241,6 +237,42 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_GH_TOKEN }}
+
+  deployment-netlify:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    environment: netlify
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Setup dependencies (cache node modules)
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Setup dependencies (setup node)
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Setup dependencies (install dependencies)
+        run: npm ci
+      - name: Setup dependencies (setup Firebase secret, others)
+        if: ${{ github.ref != 'refs/heads/master'  && github.ref != 'refs/heads/develop' }}
+        run: |
+          echo "${{ secrets.FIREBASE_CONFIG_TEST }}" > src/app/firebaseConfig.ts
+      - name: Check if push by an org member
+        id: is_organization_member
+        uses: jamessingleton/is-organization-member@1.0.1
+        with:
+          organization: EveryBoard
+          username: ${{ github.actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy feature branch if org member
         if: ${{ github.ref != 'refs/heads/master'  && github.ref != 'refs/heads/develop' }}
         run: |


### PR DESCRIPTION
Currently, feature branches are deployed to netlify only if the entire CI pipeline succeeds.
It would be more useful to deploy as soon as it builds, which is what is done here.
Develop and master still require the entire CI pipeline to succeed.