### PR TITLE
feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+ARG NODE_MAJOR_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# uncomment to install additional npm packages
+# RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "EveryBoard",
+  "dockerFile": "Dockerfile",
+  "build": {
+    "args": { "NODE_MAJOR_VERSION": "18" }
+  },
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "portsAttributes": {
+    "4200": { "label": "EveryBoard" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Angular.ng-template",
+        "dbaeumer.vscode-eslint",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # when in a VS Code or GitHub Codespaces devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ]; then
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
 	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
 	workspace_root=$(realpath ${this_dir}/..)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	# perform additional one-time setup just after
+	# the devcontainer is created
+	npm ci --prefix "${workspace_root}" # install workspace node dependencies
+
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Run `git clone https://github.com/EveryBoard/EveryBoard`
 Run `npm ci`
 
 ## Local server
-Make sure firebase emulators are installed by running `firebase init emulators`.
+Ensure you are logged in to firebase (check with `npx firebase login list`). If not you'll need to run `npx firebase login` to authenticate. Next, make sure firebase emulators are installed by running `npx firebase init emulators`.
 Then, run `npm run start:emulator` and navigate to `http://localhost:4200`
 
 ## Running unit tests


### PR DESCRIPTION
For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Remote Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `EveryBoard ` project, this configuration includes the following:
- Preinstalled `Node LTS`
- Preinstalled `ESLint`,  `Angular Language Service`, and `EditorConfig` extensions
- Automation of the `npm install` when the devcontainer is first created

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/date-fns/date-fns/pull/3551
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/compiler-explorer/compiler-explorer/pull/5631
- https://github.com/melt-ui/melt-ui/pull/658
- https://github.com/JamesLMilner/terra-draw/pull/108
